### PR TITLE
Fix extra lines in context menu again

### DIFF
--- a/chrome/popup/popup.css
+++ b/chrome/popup/popup.css
@@ -38,7 +38,7 @@ menuitem[type=radio] .menu-iconic-icon
 	margin-inline-start: 0 !important;
 }
 
-menupopup::part(content) {
+.menupopup-arrowscrollbox {
 	box-shadow: unset !important;
 	margin: 0 !important;
 }


### PR DESCRIPTION
For some reason the previous fix didn't work for me, I'm not sure if that's because Firefox updated again or if it was because I am on a different OS, but this is what I had to do to remove the extra outlines from the right click menu.

Thank you for maintaining material fox!