### PR TITLE
Fix misaligned tab seperators

### DIFF
--- a/chrome/tabbar/tabbar.css
+++ b/chrome/tabbar/tabbar.css
@@ -168,7 +168,7 @@
 	background-color: currentColor !important;
 	width: 1px !important;
 	height: 20px !important;
-	transform: translateY(-10px) !important;
+	transform: translateY(10px) !important;
 	opacity: 0 !important;
 	transition: opacity .2s var(--ease-basic) !important;
 }


### PR DESCRIPTION
Fixes issue #7 where the tab separator appears above the tab bar.

Before fix:
![image](https://user-images.githubusercontent.com/65685968/209480142-e38595c7-fffd-448a-9a65-2dc023164fbe.png)

After fix:
![image](https://user-images.githubusercontent.com/65685968/209480118-3f9902f5-49bb-4004-92eb-8a0d18747d3f.png)
